### PR TITLE
Fix some failures

### DIFF
--- a/mk/python/3.4.3/python-3.4.3-android-misc.patch
+++ b/mk/python/3.4.3/python-3.4.3-android-misc.patch
@@ -36,7 +36,7 @@ diff -ru Python-3.3.5/Lib/platform.py Python-3.3.5-android/Lib/platform.py
 +            try:
 +                result = subprocess.check_output(['/system/bin/getprop', prop],
 +                                                 pass_fds=pass_fds)
-+                return result.decode('ascii').strip()
++                return result.decode('utf-8').strip()
 +            except (subprocess.CalledProcessError, UnicodeDecodeError):
 +                raise RuntimeError('getprop failed')
 +
@@ -59,12 +59,12 @@ diff -ru Python-3.3.5/Lib/platform.py Python-3.3.5-android/Lib/platform.py
 +            if b'=' not in line:
 +                continue
 +            key, val = line.split(b'=', maxsplit=1)
-+            key = key.strip().decode('ascii')
++            key = key.strip().decode('utf-8')
 +
 +            if not version_obtained and key == _android_version_property:
-+                version = val.strip().decode('ascii')
++                version = val.strip().decode('utf-8')
 +            if not buildstr_obtained and key == _android_buildstr_property:
-+                buildstr = val.strip().decode('ascii')
++                buildstr = val.strip().decode('utf-8')
 +
 +    return version, buildstr
 +

--- a/mk/python/3.4.3/python-3.4.3-android-misc.patch
+++ b/mk/python/3.4.3/python-3.4.3-android-misc.patch
@@ -1,7 +1,7 @@
 diff -ru Python-3.3.5/Lib/platform.py Python-3.3.5-android/Lib/platform.py
 --- Python-3.3.5/Lib/platform.py	2014-03-09 09:40:13.000000000 +0100
 +++ Python-3.3.5-android/Lib/platform.py	2014-08-04 22:19:36.000000000 +0200
-@@ -368,6 +368,63 @@
+@@ -368,6 +368,76 @@
                                supported_dists=supported_dists,
                                full_distribution_name=0)
 
@@ -30,37 +30,50 @@ diff -ru Python-3.3.5/Lib/platform.py Python-3.3.5-android/Lib/platform.py
 +    # Try the 'official' API tool first, since /system/build.prop might
 +    # not be the only source for properties.
 +    if os.access('/system/bin/getprop', os.X_OK):
++        def _getprop(prop):
++            android_property_fd = _get_android_property_fd()
++            pass_fds = (android_property_fd,) if android_property_fd else ()
++            try:
++                result = subprocess.check_output(['/system/bin/getprop', prop],
++                                                 pass_fds=pass_fds)
++                return result.decode('ascii').strip()
++            except (subprocess.CalledProcessError, UnicodeDecodeError):
++                raise RuntimeError('getprop failed')
++
 +        try:
-+            output = subprocess.check_output(['/system/bin/getprop',
-+                                              _android_version_property])
-+            version = output.decode('ascii').strip()
++            version = _getprop(_android_version_property)
 +            version_obtained = True
-+        except (subprocess.CalledProcessError, UnicodeDecodeError):
++        except RuntimeError:
 +            pass
 +
 +        try:
-+            output = subprocess.check_output(['/system/bin/getprop',
-+                                              _android_buildstr_property])
-+            buildstr = output.decode('ascii').strip()
++            buildstr = _getprop(_android_buildstr_property)
 +            buildstr_obtained = True
-+        except (subprocess.CalledProcessError, UnicodeDecodeError):
++        except RuntimeError:
 +            pass
 +    done = version_obtained and buildstr_obtained
 +
 +    # Fall back to parsing /system/build.prop manually.
 +    if not done and os.path.isfile('/system/build.prop'):
-+        for line in open('/system/build.prop'):
-+            if '=' not in line:
++        for line in open('/system/build.prop', 'rb'):
++            if b'=' not in line:
 +                continue
-+            key, val = line.split('=')
-+            key = key.strip()
++            key, val = line.split(b'=', maxsplit=1)
++            key = key.strip().decode('ascii')
 +
 +            if not version_obtained and key == _android_version_property:
-+                version = val.strip()
-+            elif not buildstr_obtained and key == _android_buildstr_property:
-+                buildstr = val.strip()
++                version = val.strip().decode('ascii')
++            if not buildstr_obtained and key == _android_buildstr_property:
++                buildstr = val.strip().decode('ascii')
 +
 +    return version, buildstr
++
++def _get_android_property_fd():
++    android_property_workspace = os.getenv('ANDROID_PROPERTY_WORKSPACE')
++    if android_property_workspace:
++        property_fd_str = android_property_workspace.split(',')[0]
++        if property_fd_str.isdigit():
++            return int(property_fd_str)
 +
  def popen(cmd, mode='r', bufsize=-1):
 

--- a/mk/python/3.4.3/python-3.4.3-python-misc.patch
+++ b/mk/python/3.4.3/python-3.4.3-python-misc.patch
@@ -64,6 +64,16 @@ diff -ru Python-3.3.5/setup.py Python-3.3.5-android/setup.py
          lib = sysconfig.get_config_var('TIMEMODULE_LIB')
          if lib:
              time_libs.append(lib)
+@@ -631,7 +631,8 @@
+             missing.append('spwd')
+ 
+         # select(2); not on ancient System V
+-        exts.append( Extension('select', ['selectmodule.c']) )
++        exts.append( Extension('select', ['selectmodule.c'],
++                               libraries=['m']) )
+ 
+         # Fred Drake's interface to the Python parser
+         exts.append( Extension('parser', ['parsermodule.c']) )
 @@ -639,7 +639,8 @@
          # Operations on audio samples
          # According to #993173, this one should actually work fine on


### PR DESCRIPTION
This PR contains two parts:
1. fix ```platform.android_version()```
On my first phone ```subprocess.check_call(['/system/bin/getprop', 'ro.build.version.release'])``` returns empty string ```b''```, while in adb shell, ```/system/bin/getprop ro.build.version.release``` returns '4.1.1'. I don't know why but I try to make the falling back part working.

Then it's the problem of binary/unicode. My ```/system/build.prop``` contains the following line:
```
ro.build.date=五  3月 15 13:39:06 CST 2013
```
Non-ascii characters forces me to read in binary data first and then explicitly decode them.

Finally on my another phone ```/system/build.prop``` contains the following line:
```
dalvik.vm.dexopt-flags=m=y
```
As a result, I need the ```maxsplit``` parameter.
2. Correct libm.so dependency in selectmodule.c
Since [cpython hg 88854](https://hg.python.org/cpython/rev/827d948ac6aa), ```Modules/selectmodule.c``` contains a ```ceil``` call. Without explicitly linking to libm.so, ```import select``` fails.

With the above two fixes, I can run [youtube-dl](https://github.com/rg3/youtube-dl) with the following command:
```
python3 youtube-dl -v --no-check-certificate mugIxP3LFhw
```

Tested environments:
1. HTC butterfly x920d with official 4.1.1 ROM
2. Samsung Galaxy Note N7000 with my own CyanogenMod 11.0 build, Android 4.4.4